### PR TITLE
Search directories recursively

### DIFF
--- a/lib/scanner/generic.rb
+++ b/lib/scanner/generic.rb
@@ -198,8 +198,8 @@ module Yawast
         end
       end
 
-      def self.directory_search(uri)
-        puts 'Searching for common directories...'
+      def self.directory_search(uri, banner = true)
+        puts 'Searching for common directories...' if banner
 
         File.open("lib/resources/common.txt", "r") do |f|
           f.each_line do |line|
@@ -210,11 +210,12 @@ module Yawast
 
             if code == "200"
               Yawast::Utilities.puts_info "\tFound: '#{check.to_s}'"
+              directory_search check, false
             end
           end
         end
 
-        puts ''
+        puts '' if banner
       end
 
       def self.check_options(uri)


### PR DESCRIPTION
This updates the search method to also execute on each directory that it finds, creating far more detail compared to the current method that only looks for top level directories.

Downside: This is *slow* - very slow. At this time, not sure if it'll be merged, as it can run for hours in some cases, which is just too slow to be reasonably useful.

Options: Could thread off the requests, although at this time everything is blocking, so we don't pound targets. This would be a real departure from that stance.

Fixes #47