### PR TITLE
Basic SWEET32 checking (kinda)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ SSL Information:
 * Certificate details
 * Certificate chain
 * Supported ciphers
+* Maximum requests in a single connection
 
 Checks for the following SSL issues are performed:
 
@@ -193,7 +194,7 @@ For authenticated testing, YAWAST allows you to specify a cookie to be passed vi
 Using `scan` - the normal go-to option, here's what you get when scanning my website:
 
 ```
-$yawast scan https://adamcaudill.com --dir
+$yawast scan https://adamcaudill.com --sslsessioncount --dir
 __   _____  _    _  ___   _____ _____ 
 \ \ / / _ \| |  | |/ _ \ /  ___|_   _|
  \ V / /_\ \ |  | / /_\ \\ `--.  | |  
@@ -215,10 +216,10 @@ DNS Information:
 [I] 		104.28.26.55 (N/A)
 				https://www.shodan.io/host/104.28.26.55
 				https://censys.io/ipv4/104.28.26.55
-[I] 		2400:CB00:2048:1::681C:1B37 (N/A)
-				https://www.shodan.io/host/2400:cb00:2048:1::681c:1b37
 [I] 		2400:CB00:2048:1::681C:1A37 (N/A)
 				https://www.shodan.io/host/2400:cb00:2048:1::681c:1a37
+[I] 		2400:CB00:2048:1::681C:1B37 (N/A)
+				https://www.shodan.io/host/2400:cb00:2048:1::681c:1b37
 [I] 		TXT: v=spf1 mx a ptr include:_spf.google.com ~all
 [I] 		MX: aspmx4.googlemail.com (30)
 [I] 		MX: aspmx.l.google.com (10)
@@ -231,19 +232,17 @@ DNS Information:
 [I] 		NS: hal.ns.cloudflare.com
 
 [I] HEAD:
-[I] 		date: Tue, 16 Aug 2016 07:50:45 GMT
+[I] 		date: Thu, 25 Aug 2016 16:51:27 GMT
 [I] 		content-type: text/html; charset=UTF-8
 [I] 		connection: close
-[I] 		set-cookie: __cfduid=1; expires=Wed, 16-Aug-17 07:50:45 GMT; path=/; domain=.adamcaudill.com; HttpOnly
+[I] 		set-cookie: __cfduid=1; expires=Fri, 25-Aug-17 16:51:26 GMT; path=/; domain=.adamcaudill.com; HttpOnly
 [I] 		vary: Accept-Encoding,Cookie
-[I] 		cache-control: max-age=3, must-revalidate
-[I] 		wp-super-cache: Served supercache file from PHP
-[I] 		last-modified: Tue, 16 Aug 2016 07:47:59 GMT
+[I] 		link: <https://adamcaudill.com/wp-json/>; rel="https://api.w.org/"
 [I] 		x-frame-options: sameorigin
 [I] 		strict-transport-security: max-age=15552000; preload
 [I] 		x-content-type-options: nosniff
 [I] 		server: cloudflare-nginx
-[I] 		cf-ray: 2d334c1687ed2e75-MIA
+[I] 		cf-ray: 2d808c7c54cd50b0-MIA
 
 [I] NOTE: Server appears to be Cloudflare; WAF may be in place.
 
@@ -253,19 +252,15 @@ DNS Information:
 [W] Public-Key-Pins Header Not Present
 
 [I] Cookies:
-[I] 		__cfduid=1; expires=Wed, 16-Aug-17 07:50:45 GMT; path=/; domain=.adamcaudill.com; HttpOnly
+[I] 		__cfduid=1; expires=Fri, 25-Aug-17 16:51:26 GMT; path=/; domain=.adamcaudill.com; HttpOnly
 [W] 			Cookie missing Secure flag
 
 
 Beginning SSL Labs scan (this could take a minute or two)
 [SSL Labs]	This assessment service is provided free of charge by Qualys SSL Labs, subject to our terms and conditions: https://www.ssllabs.com/about/terms.html
-.
+...........................................
 
-[I] IP: 104.28.27.55 - Grade: 
-
-[E] Error getting information for IP: 104.28.27.55: Unable to connect to the server
-
-[I] IP: 2400:cb00:2048:1:0:0:681c:1b37 - Grade: A+
+[I] IP: 104.28.27.55 - Grade: A+
 
 	Certificate Information:
 [I] 		Subject: CN=sni67677.cloudflaressl.com,OU=PositiveSSL Multi-Domain,OU=Domain Control Validated
@@ -277,7 +272,7 @@ Beginning SSL Labs scan (this could take a minute or two)
 [I] 		Not Before: 2016-08-13T00:00:00+00:00
 [I] 		Not After: 2017-02-12T23:59:59+00:00
 [I] 		Key: EC 256 (RSA equivalent: 3072)
-[I] 		Key Hash: 1a8aa5b45b60dfbafab92c0f11704c2aebe45d31
+[I] 		Key Hash: 5e224ee926c65431fbf5cf5d54abb9b9e32b3501
 [I] 		Serial: 18930702358496442989903109042193740748
 [I] 		Issuer: COMODO ECC Domain Validation Secure Server CA 2
 [I] 		Signature algorithm: SHA256withECDSA
@@ -371,220 +366,9 @@ Beginning SSL Labs scan (this could take a minute or two)
 [I] 			Logjam: No
 [I] 			DH public server param (Ys) reuse: No
 
-
-[I] IP: 104.28.26.55 - Grade: A+
-
-	Certificate Information:
-[I] 		Subject: CN=sni67677.cloudflaressl.com,OU=PositiveSSL Multi-Domain,OU=Domain Control Validated
-[I] 		Common Names: ["sni67677.cloudflaressl.com"]
-[I] 		Alternative names:
-[I] 			sni67677.cloudflaressl.com
-[I] 			*.adamcaudill.com
-[I] 			adamcaudill.com
-[I] 		Not Before: 2016-08-13T00:00:00+00:00
-[I] 		Not After: 2017-02-12T23:59:59+00:00
-[I] 		Key: EC 256 (RSA equivalent: 3072)
-[I] 		Key Hash: c6c369ae2f94fdeeb382099922fa1febe80d6642
-[I] 		Serial: 18930702358496442989903109042193740748
-[I] 		Issuer: COMODO ECC Domain Validation Secure Server CA 2
-[I] 		Signature algorithm: SHA256withECDSA
-[I] 		Extended Validation: No (Domain Control)
-[I] 		Certificate Transparency: No
-[I] 		OCSP Must Staple: No
-[I] 		Revocation information: CRL information available
-[I] 		Revocation information: OCSP information available
-[I] 		Revocation status: certificate not revoked
-[I] 		Hash: 1ae6362e4fc377cccb6df6261838a5d9bb49663d
-			https://censys.io/certificates?q=1ae6362e4fc377cccb6df6261838a5d9bb49663d
-			https://crt.sh/?q=1ae6362e4fc377cccb6df6261838a5d9bb49663d
-
-	Configuration Information:
-		Protocol Support:
-[I] 			TLS 1.0
-[I] 			TLS 1.1
-[I] 			TLS 1.2
-
-		Cipher Suite Support:
-[I] 			TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256            - 128-bits - ECDHE-256-bits
-[I] 			TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256            - 128-bits - ECDHE-256-bits
-[I] 			TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA               - 128-bits - ECDHE-256-bits
-[I] 			TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384            - 256-bits - ECDHE-256-bits
-[I] 			TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384            - 256-bits - ECDHE-256-bits
-[I] 			TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA               - 256-bits - ECDHE-256-bits
-[W] 			TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA              - 112-bits - ECDHE-256-bits
-[I] 			TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256      - 256-bits - ECDHE-256-bits
-[I] 			OLD_TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256  - 256-bits - ECDHE-256-bits
-
-		Handshake Simulation:
-[E] 			Android 2.3.7                - Simulation Failed
-[I] 			Android 4.0.4                - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			Android 4.1.1                - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			Android 4.2.2                - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			Android 4.3                  - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			Android 4.4.2                - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Android 5.0.0                - TLS 1.2 - OLD_TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-[I] 			Android 6.0                  - TLS 1.2 - OLD_TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-[I] 			Baidu Jan 2015               - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			BingPreview Jan 2015         - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Chrome 51 / Win 7            - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Firefox 31.3.0 ESR / Win 7   - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Firefox 46 / Win 7           - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Firefox 47 / Win 7           - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Googlebot Feb 2015           - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[E] 			IE 6 / XP                    - Simulation Failed
-[I] 			IE 7 / Vista                 - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[E] 			IE 8 / XP                    - Simulation Failed
-[I] 			IE 8-10 / Win 7              - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			IE 11 / Win 7                - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			IE 11 / Win 8.1              - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			IE 10 / Win Phone 8.0        - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			IE 11 / Win Phone 8.1        - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			IE 11 / Win Phone 8.1 Update - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			IE 11 / Win 10               - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Edge 13 / Win 10             - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Edge 13 / Win Phone 10       - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[E] 			Java 6u45                    - Simulation Failed
-[I] 			Java 7u25                    - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			Java 8u31                    - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[E] 			OpenSSL 0.9.8y               - Simulation Failed
-[I] 			OpenSSL 1.0.1l               - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			OpenSSL 1.0.2e               - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Safari 5.1.9 / OS X 10.6.8   - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			Safari 6 / iOS 6.0.1         - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-[I] 			Safari 6.0.4 / OS X 10.8.4   - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			Safari 7 / iOS 7.1           - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-[I] 			Safari 7 / OS X 10.9         - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-[I] 			Safari 8 / iOS 8.4           - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-[I] 			Safari 8 / OS X 10.10        - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-[I] 			Safari 9 / iOS 9             - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Safari 9 / OS X 10.11        - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Apple ATS 9 / iOS 9          - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Yahoo Slurp Jan 2015         - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			YandexBot Jan 2015           - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-
-		Protocol & Vulnerability Information:
-[I] 			DROWN: No
-[I] 			Secure Renegotiation: secure renegotiation supported
-[I] 			POODLE (SSL): No
-[I] 			POODLE (TLS): No
-[I] 			Downgrade Prevention: Yes
-[I] 			Compression: No
-[I] 			Heartbleed: No
-[I] 			OpenSSL CCS (CVE-2014-0224): No
-[I] 			OpenSSL Padding Oracle (CVE-2016-2107): No
-[I] 			Forward Secrecy: Yes (all simulated clients)
-[I] 			OCSP Stapling: Yes
-[I] 			FREAK: No
-[I] 			Logjam: No
-[I] 			DH public server param (Ys) reuse: No
-
-
-[I] IP: 2400:cb00:2048:1:0:0:681c:1a37 - Grade: A+
-
-	Certificate Information:
-[I] 		Subject: CN=sni67677.cloudflaressl.com,OU=PositiveSSL Multi-Domain,OU=Domain Control Validated
-[I] 		Common Names: ["sni67677.cloudflaressl.com"]
-[I] 		Alternative names:
-[I] 			sni67677.cloudflaressl.com
-[I] 			*.adamcaudill.com
-[I] 			adamcaudill.com
-[I] 		Not Before: 2016-08-13T00:00:00+00:00
-[I] 		Not After: 2017-02-12T23:59:59+00:00
-[I] 		Key: EC 256 (RSA equivalent: 3072)
-[I] 		Key Hash: cc8cc14246778e98d0792316d299b9c452dd0f68
-[I] 		Serial: 18930702358496442989903109042193740748
-[I] 		Issuer: COMODO ECC Domain Validation Secure Server CA 2
-[I] 		Signature algorithm: SHA256withECDSA
-[I] 		Extended Validation: No (Domain Control)
-[I] 		Certificate Transparency: No
-[I] 		OCSP Must Staple: No
-[I] 		Revocation information: CRL information available
-[I] 		Revocation information: OCSP information available
-[I] 		Revocation status: certificate not revoked
-[I] 		Hash: 1ae6362e4fc377cccb6df6261838a5d9bb49663d
-			https://censys.io/certificates?q=1ae6362e4fc377cccb6df6261838a5d9bb49663d
-			https://crt.sh/?q=1ae6362e4fc377cccb6df6261838a5d9bb49663d
-
-	Configuration Information:
-		Protocol Support:
-[I] 			TLS 1.0
-[I] 			TLS 1.1
-[I] 			TLS 1.2
-
-		Cipher Suite Support:
-[I] 			TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256            - 128-bits - ECDHE-256-bits
-[I] 			TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256            - 128-bits - ECDHE-256-bits
-[I] 			TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA               - 128-bits - ECDHE-256-bits
-[I] 			TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384            - 256-bits - ECDHE-256-bits
-[I] 			TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384            - 256-bits - ECDHE-256-bits
-[I] 			TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA               - 256-bits - ECDHE-256-bits
-[W] 			TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA              - 112-bits - ECDHE-256-bits
-[I] 			TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256      - 256-bits - ECDHE-256-bits
-[I] 			OLD_TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256  - 256-bits - ECDHE-256-bits
-
-		Handshake Simulation:
-[E] 			Android 2.3.7                - Simulation Failed
-[I] 			Android 4.0.4                - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			Android 4.1.1                - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			Android 4.2.2                - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			Android 4.3                  - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			Android 4.4.2                - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Android 5.0.0                - TLS 1.2 - OLD_TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-[I] 			Android 6.0                  - TLS 1.2 - OLD_TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-[I] 			Baidu Jan 2015               - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			BingPreview Jan 2015         - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Chrome 51 / Win 7            - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Firefox 31.3.0 ESR / Win 7   - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Firefox 46 / Win 7           - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Firefox 47 / Win 7           - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Googlebot Feb 2015           - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[E] 			IE 6 / XP                    - Simulation Failed
-[I] 			IE 7 / Vista                 - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[E] 			IE 8 / XP                    - Simulation Failed
-[I] 			IE 8-10 / Win 7              - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			IE 11 / Win 7                - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			IE 11 / Win 8.1              - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			IE 10 / Win Phone 8.0        - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			IE 11 / Win Phone 8.1        - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			IE 11 / Win Phone 8.1 Update - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			IE 11 / Win 10               - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Edge 13 / Win 10             - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Edge 13 / Win Phone 10       - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[E] 			Java 6u45                    - Simulation Failed
-[I] 			Java 7u25                    - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			Java 8u31                    - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[E] 			OpenSSL 0.9.8y               - Simulation Failed
-[I] 			OpenSSL 1.0.1l               - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			OpenSSL 1.0.2e               - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Safari 5.1.9 / OS X 10.6.8   - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			Safari 6 / iOS 6.0.1         - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-[I] 			Safari 6.0.4 / OS X 10.8.4   - TLS 1.0 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-[I] 			Safari 7 / iOS 7.1           - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-[I] 			Safari 7 / OS X 10.9         - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-[I] 			Safari 8 / iOS 8.4           - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-[I] 			Safari 8 / OS X 10.10        - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-[I] 			Safari 9 / iOS 9             - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Safari 9 / OS X 10.11        - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Apple ATS 9 / iOS 9          - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			Yahoo Slurp Jan 2015         - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-[I] 			YandexBot Jan 2015           - TLS 1.2 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-
-		Protocol & Vulnerability Information:
-[I] 			DROWN: No
-[I] 			Secure Renegotiation: secure renegotiation supported
-[I] 			POODLE (SSL): No
-[I] 			POODLE (TLS): No
-[I] 			Downgrade Prevention: Yes
-[I] 			Compression: No
-[I] 			Heartbleed: No
-[I] 			OpenSSL CCS (CVE-2014-0224): No
-[I] 			OpenSSL Padding Oracle (CVE-2016-2107): No
-[I] 			Forward Secrecy: Yes (all simulated clients)
-[I] 			OCSP Stapling: Yes
-[I] 			FREAK: No
-[I] 			Logjam: No
-[I] 			DH public server param (Ys) reuse: No
-
+SSL Session Request Limit: Checking number of requests accepted...
+.....
+[I] SSL Session Request Limit: Connection terminated after 100 requests (SSL Reconnected)
 
 [I] HSTS: Enabled (strict-transport-security: max-age=15552000; preload)
 
@@ -614,7 +398,7 @@ Searching for common directories...
 [I] 	Found: 'https://adamcaudill.com/wp-content/'
 [I] 	Found: 'https://adamcaudill.com/wp-includes/'
 
-[I] Meta Generator: WordPress 4.5.3
+[I] Meta Generator: WordPress 4.6
 Scan complete.
 ```
 

--- a/lib/scanner/core.rb
+++ b/lib/scanner/core.rb
@@ -80,9 +80,9 @@ module Yawast
           head = Yawast::Shared::Http.head(uri) if head == nil
 
           if options.internalssl
-            Yawast::Scanner::Ssl.info(uri, !options.nociphers)
+            Yawast::Scanner::Ssl.info(uri, !options.nociphers, options.sweet32count)
           else
-            Yawast::Scanner::SslLabs.info(uri)
+            Yawast::Scanner::SslLabs.info(uri, options.sweet32count)
           end
 
           Yawast::Scanner::Ssl.check_hsts(head)

--- a/lib/scanner/core.rb
+++ b/lib/scanner/core.rb
@@ -82,7 +82,7 @@ module Yawast
           if options.internalssl
             Yawast::Scanner::Ssl.info(uri, !options.nociphers, options.sweet32count)
           else
-            Yawast::Scanner::SslLabs.info(uri, options.sweet32count)
+            Yawast::Scanner::SslLabs.info(uri, options.sslsessioncount)
           end
 
           Yawast::Scanner::Ssl.check_hsts(head)

--- a/lib/scanner/ssl.rb
+++ b/lib/scanner/ssl.rb
@@ -5,7 +5,7 @@ require 'digest/sha1'
 module Yawast
   module Scanner
     class Ssl
-      def self.info(uri, check_ciphers, sweet32_count)
+      def self.info(uri, check_ciphers, sslsessioncount)
         begin
           socket = TCPSocket.new(uri.host, uri.port)
 
@@ -98,7 +98,7 @@ module Yawast
 
           ssl.sysclose
 
-          get_session_msg_count(uri) if sweet32_count
+          get_session_msg_count(uri) if sslsessioncount
         rescue => e
           Yawast::Utilities.puts_error "SSL: Error Reading X509 Details: #{e.message}"
         end
@@ -181,7 +181,7 @@ module Yawast
         def self.get_session_msg_count(uri)
           # this method will send a number of HEAD requests to see
           #  if the connection is eventually killed.
-          puts 'SWEET32: Checking number of requests accepted...'
+          puts 'SSL Session Request Limit: Checking number of requests accepted...'
 
           count = 0
           begin
@@ -208,12 +208,12 @@ module Yawast
             end
           rescue => e
             puts
-            Yawast::Utilities.puts_info "SWEET32: Connection terminated after #{count} requests (#{e.message})"
+            Yawast::Utilities.puts_info "SSL Session Request Limit: Connection terminated after #{count} requests (#{e.message})"
             return
           end
 
           puts
-          Yawast::Utilities.puts_warn 'SWEET32: Connection not terminated after 10,000 requests'
+          Yawast::Utilities.puts_warn 'SSL Session Request Limit: Connection not terminated after 10,000 requests; may be affected by SWEET32'
         end
 
       #private methods

--- a/lib/scanner/ssl_labs.rb
+++ b/lib/scanner/ssl_labs.rb
@@ -6,7 +6,7 @@ require 'digest/sha1'
 module Yawast
   module Scanner
     class SslLabs
-      def self.info(uri)
+      def self.info(uri, sweet32_count)
         puts 'Beginning SSL Labs scan (this could take a minute or two)'
 
         api = Ssllabs::Api.new
@@ -18,7 +18,7 @@ module Yawast
         end
 
         begin
-          api.analyse(host: uri.host, publish: 'off', startNew: 'on', all: 'done', ignoreMismatch: 'on')
+          api.analyse(host: uri.host, publish: 'off', fromCache: 'on', all: 'done', ignoreMismatch: 'on')
 
           status = ''
           host = nil
@@ -50,6 +50,8 @@ module Yawast
             rescue => e
               Yawast::Utilities.puts_error "Error getting information for IP: #{ep.ip_address}: #{e.message}"
             end
+
+            Yawast::Scanner::Ssl.get_session_msg_count(uri) if sweet32_count
 
             puts
           end

--- a/lib/scanner/ssl_labs.rb
+++ b/lib/scanner/ssl_labs.rb
@@ -18,7 +18,7 @@ module Yawast
         end
 
         begin
-          api.analyse(host: uri.host, publish: 'off', fromCache: 'on', all: 'done', ignoreMismatch: 'on')
+          api.analyse(host: uri.host, publish: 'off', startNew: 'on', all: 'done', ignoreMismatch: 'on')
 
           status = ''
           host = nil

--- a/lib/scanner/ssl_labs.rb
+++ b/lib/scanner/ssl_labs.rb
@@ -6,7 +6,7 @@ require 'digest/sha1'
 module Yawast
   module Scanner
     class SslLabs
-      def self.info(uri, sweet32_count)
+      def self.info(uri, sslsessioncount)
         puts 'Beginning SSL Labs scan (this could take a minute or two)'
 
         api = Ssllabs::Api.new
@@ -51,7 +51,7 @@ module Yawast
               Yawast::Utilities.puts_error "Error getting information for IP: #{ep.ip_address}: #{e.message}"
             end
 
-            Yawast::Scanner::Ssl.get_session_msg_count(uri) if sweet32_count
+            Yawast::Scanner::Ssl.get_session_msg_count(uri) if sslsessioncount
 
             puts
           end

--- a/yawast
+++ b/yawast
@@ -17,6 +17,7 @@ command :scan do |c|
   c.option '--nossl', 'Disables SSL checks'
   c.option '--nociphers', 'Disables check for supported ciphers'
   c.option '--internalssl', 'Disable SSL Labs integration'
+  c.option '--sweet32count', 'Counts the number of messages that can be sent in a single session'
   c.option '--dir', 'Enables directory search'
   c.option '--proxy STRING', String, 'HTTP Proxy Server (such as Burp Suite)'
   c.option '--cookie STRING', String, 'Session cookie'
@@ -33,6 +34,7 @@ command :head do |c|
   c.option '--nossl', 'Disables SSL checks'
   c.option '--nociphers', 'Disables check for supported ciphers'
   c.option '--internalssl', 'Disable SSL Labs integration'
+  c.option '--sweet32count', 'Counts the number of messages that can be sent in a single session'
   c.option '--proxy STRING', String, 'HTTP Proxy Server (such as Burp Suite)'
   c.option '--cookie STRING', String, 'Session cookie'
 
@@ -47,6 +49,7 @@ command :ssl do |c|
 
   c.option '--nociphers', 'Disables check for supported ciphers'
   c.option '--internalssl', 'Disable SSL Labs integration'
+  c.option '--sweet32count', 'Counts the number of messages that can be sent in a single session'
 
   c.action do |args, options|
     Yawast::Commands::Ssl.process(args, options)

--- a/yawast
+++ b/yawast
@@ -17,7 +17,7 @@ command :scan do |c|
   c.option '--nossl', 'Disables SSL checks'
   c.option '--nociphers', 'Disables check for supported ciphers'
   c.option '--internalssl', 'Disable SSL Labs integration'
-  c.option '--sweet32count', 'Counts the number of messages that can be sent in a single session'
+  c.option '--sslsessioncount', 'Counts the number of messages that can be sent in a single session'
   c.option '--dir', 'Enables directory search'
   c.option '--proxy STRING', String, 'HTTP Proxy Server (such as Burp Suite)'
   c.option '--cookie STRING', String, 'Session cookie'
@@ -34,7 +34,7 @@ command :head do |c|
   c.option '--nossl', 'Disables SSL checks'
   c.option '--nociphers', 'Disables check for supported ciphers'
   c.option '--internalssl', 'Disable SSL Labs integration'
-  c.option '--sweet32count', 'Counts the number of messages that can be sent in a single session'
+  c.option '--sslsessioncount', 'Counts the number of messages that can be sent in a single session'
   c.option '--proxy STRING', String, 'HTTP Proxy Server (such as Burp Suite)'
   c.option '--cookie STRING', String, 'Session cookie'
 
@@ -49,7 +49,7 @@ command :ssl do |c|
 
   c.option '--nociphers', 'Disables check for supported ciphers'
   c.option '--internalssl', 'Disable SSL Labs integration'
-  c.option '--sweet32count', 'Counts the number of messages that can be sent in a single session'
+  c.option '--sslsessioncount', 'Counts the number of messages that can be sent in a single session'
 
   c.action do |args, options|
     Yawast::Commands::Ssl.process(args, options)


### PR DESCRIPTION
This change adds a new command line parameter, `--sslsessioncount` which will cause the application to send up to 10,000 `HEAD` requests to the target server. If keep-alive limiting is in place, this should show it (unless it's > 10,000).

This currently only prints a warning, as we can't say it is actually vulnerable, just could be. Anything thing this doesn't (currently) do is verify that the server is using 3DES (this *may* be added later). This option is off by default, and intended for those that know why they are using it. 

The output will look something like this:

```
SSL Session Request Limit: Checking number of requests accepted...
...
[I] SSL Session Request Limit: Connection terminated after 50 requests (SSL Reconnected)
```