### PR TITLE
Add Dockerfile and relevant docs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:2.4-stretch
+
+COPY . /data
+WORKDIR /data
+
+ENV LANG      C.UTF-8
+ENV LANGUAGE  C.UTF-8
+ENV LC_ALL    C.UTF-8
+
+RUN bundle
+
+ENTRYPOINT ["yawast"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-stretch
+FROM ruby:2.4-jessie
 
 COPY . /data
 WORKDIR /data
@@ -9,4 +9,4 @@ ENV LC_ALL    C.UTF-8
 
 RUN bundle
 
-ENTRYPOINT ["yawast"]
+ENTRYPOINT ["/data/bin/yawast"]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To install on Windows, you need to first install Ruby; this can be done easily w
 YAWAST can be run inside a docker container.
 
 ```
-docker run --rm yawast scan <url> ...
+docker run --rm adamcaudill/yawast scan <url> ...
 ```
 
 ### Tests

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ gem install yawast
 
 To install on Windows, you need to first install Ruby; this can be done easily with the latest version of [RubyInstaller](https://rubyinstaller.org/downloads/). Once Ruby is installed, YAWAST can be installed via `gem install yawast` as normal.
 
+**Docker**
+
+YAWAST can be run inside a docker container.
+
+```
+docker run --rm yawast scan <url> ...
+```
+
 ### Tests
 
 The following tests are performed:


### PR DESCRIPTION
## What does this PR do?

Fixes #119.

* Adds `Dockerfile` based on Debian Jessie.
* Adds basic usage notes in `README.md`

Note that I used a Debian Jessie base image so that the earlier version of openssl was available for SWEET32 test.

## How should it be tested?

* Check out this branch
* Build the image `docker build -t yawast-test .`
* Run a test `docker run --rm yawast-test scan https://www.github.com`

## Any required updates to documentation?

Maybe some additional usage examples, but the current level of docs will get someone started.

