### PR TITLE
We should only import cx_Freeze for EXEs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,17 @@
 import sys
 from setuptools import find_packages
-from cx_Freeze import Executable
 from os import path
 
 if "build_exe" in sys.argv:
-    from cx_Freeze import setup
+    from cx_Freeze import setup, Executable
 else:
     from setuptools import setup
+
+    # fake Executable class to avoid cx_Freeze on non-Windows
+    class Executable:
+        def __init__(self, script, targetName):
+            pass
+
 
 # Dependencies are automatically detected.
 # I'm not sure about the *version.py files, but this hack works.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ else:
 
     # fake Executable class to avoid cx_Freeze on non-Windows
     class Executable:
-        def __init__(self, script, targetName):
+        def __init__(self, script=None, base=None):
             pass
 
 


### PR DESCRIPTION
We are currently pulling in cx_Freeze for all systems, when it's only needed for building an EXE - non-Windows devices shouldn't need to worry about it.