### PR TITLE
Switch to 2.6.0 of jsonschema.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,8 @@ cx-Freeze==5.1.1
 dnspython==1.16.0
 idna==2.8
 jsonschema==2.6.0
-mypy==0.720
-mypy-extensions==0.4.1
 nassl==2.2.0
 packaging==19.1
-pipenv==2018.11.26
 psutil==5.6.3
 publicsuffixlist==0.6.10
 pycparser==2.19
@@ -28,9 +25,5 @@ six==1.12.0
 soupsieve==1.9.2
 sslyze==2.1.3
 tls-parser==1.2.1
-typed-ast==1.4.0
-typing-extensions==3.7.4
 urllib3==1.25.3
 validator-collection==1.3.5
-virtualenv==16.7.2
-virtualenv-clone==0.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cryptography==2.5
 cx-Freeze==5.1.1
 dnspython==1.16.0
 idna==2.8
-jsonschema==3.0.1
+jsonschema==2.6.0
 mypy==0.720
 mypy-extensions==0.4.1
 nassl==2.2.0


### PR DESCRIPTION
3.x produces a cryptic error in frozen executables on Windows.